### PR TITLE
i2180: Add new args to schedule.py, and update cli.py to use docopt.

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,27 +1,37 @@
 #!/usr/bin/env python3
+"""
+Duplicati CLI wrapper
+
+Usage:
+  cli.py TARGET TASK [ADDITIONAL_ARGS ...]
+  cli.py list-targets
+
+Where:
+  TARGET is the id of a target in the current config
+  TASK is a duplicati-cli task (see https://duplicati.readthedocs.io/en/latest/04-using-duplicati-from-the-command-line/)
+  and any additional arguments are passed to duplicati-cli
+"""
+
 from subprocess import run
 
-import sys
+from docopt import docopt
 
 from settings import load_settings, shared_args
 
-usage = """Usage:
-./cli.py TARGET TASK ...
-where:
-  TARGET is the id of a target in the current config
-  TASK is a duplicati-cli task (see https://duplicati.readthedocs.io/en/latest/04-using-duplicati-from-the-command-line/)
-  and ... is any additional arguments to pass to duplicati-cli"""
 
-if __name__ == "__main__":
-    settings = load_settings()
-    if len(sys.argv) < 3:
-        print(usage)
-        exit(1)
-        
-    target = next(t for t in settings.targets if t.id == sys.argv[1])
-    task = sys.argv[2]
-    cmd = ["duplicati-cli", task, target.remote_url]
-    if len(sys.argv) > 3:
-        cmd += sys.argv[3:]
+def run_task(options, settings):
+    target = next(t for t in settings.targets if t.id == options["TARGET"])
+    cmd = ["duplicati-cli", options["TASK"], target.remote_url]
+    cmd += options["ADDITIONAL_ARGS"]
     cmd += shared_args(settings, target.encrypted)
     run(cmd)
+
+
+if __name__ == "__main__":
+    options = docopt(__doc__)
+    settings = load_settings()
+    if options["list-targets"]:
+        for target in settings.targets:
+            print(target.id)
+    else:
+        run_task(options, settings)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-python-crontab==2.2.3
+python-crontab>=2.2.3
+docopt>=0.6.2


### PR DESCRIPTION
https://vimc.myjetbrains.com/youtrack/issue/VIMC-2180

In order to handle args I added docopt. At which point, since we are now investing in this tool again, I thought I should take a minute to go upgrade the `cli.py` tool to also use docopt.