### PR TITLE
i2485: Reorder backups

### DIFF
--- a/configs/annex.json
+++ b/configs/annex.json
@@ -1,14 +1,6 @@
 {
     "targets": [
         {
-            "id": "main_db",
-            "type": "directory",
-            "path": "/home/montagu/starport/main_db_restore",
-            "s3_bucket": "montagu-db",
-            "encrypted": true,
-            "max_versions": 90
-        },
-        {
             "id": "orderly",
             "type": "directory",
             "path": "/home/montagu/starport/orderly",
@@ -30,6 +22,14 @@
             "path": "/home/montagu/starport/vault",
             "s3_bucket": "montagu-vault",
             "encrypted": false
+        },
+        {
+            "id": "main_db",
+            "type": "directory",
+            "path": "/home/montagu/starport/main_db_restore",
+            "s3_bucket": "montagu-db",
+            "encrypted": true,
+            "max_versions": 90
         }
     ]
 }


### PR DESCRIPTION
This goes part way to resolving VIMC-2485 and should be enough
to avoid the worst of the monitoring noise

NOTE: the issue was originally to remove the backup entirely - do we have a strong reason for keeping it?